### PR TITLE
Fixed link for debug bar plugin

### DIFF
--- a/debug-bar-shortcodes.php
+++ b/debug-bar-shortcodes.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'debug_bar_shortcodes_has_parent_plugin' ) ) {
 
 		if ( is_admin() && ( ! class_exists( 'Debug_Bar' ) && current_user_can( 'activate_plugins' ) ) && is_plugin_active( $file ) ) {
 
-			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\' . sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Shortcodes</strong> Plugin. %sVisit your plugins page to activate.\', \'debug-bar-shortcodes\' ), \'<a href="\' . admin_url( \'plugins.php#debug-bar\' ) . \'">\' ) . \'</a></p></div>\';' ) );
+			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\' . sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Shortcodes</strong> Plugin. %sVisit your plugins page to install & activate.\', \'debug-bar-shortcodes\' ), \'<a href="\' . admin_url( \'plugin-install.php?tab=search&s=debug+bar\' ) . \'">\' ) . \'</a></p></div>\';' ) );
 
 			deactivate_plugins( $file, false, is_network_admin() );
 


### PR DESCRIPTION
While replying at support forum for question [Can't test because need to be activate](https://wordpress.org/support/topic/cant-test-because-need-to-be-activate?replies=1), so I have fixed the link and create pull request. 
