### PR TITLE
Feature/qa update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,14 @@ matrix:
   include:
     # aliased to 5.2.17
     - php: '5.2'
+    # aliased to 5.3.29
+    - php: '5.3'
+      env: CLOSURE=1
     # aliased to a recent 5.4.x version
     - php: '5.4'
+      env: CLOSURE=1
+    # aliased to a recent 5.5.x version
+    - php: '5.5'
       env: CLOSURE=1
     # aliased to a recent 5.6.x version
     - php: '5.6'
@@ -27,33 +33,38 @@ matrix:
     # aliased to a recent 7.1.x version
     - php: '7.1'
       env: CLOSURE=1
-    # aliased to a recent hhvm version
-    - php: 'hhvm'
+    # bleeding edge
+    - php: 'nightly'
       env: CLOSURE=1
 
   allow_failures:
-    - php: 'hhvm'
+    - php: 'nightly'
 
-before_script:
+before_install:
     - export PHPCS_DIR=/tmp/phpcs
     - export SNIFFS_DIR=/tmp/sniffs
     # Install CodeSniffer for WordPress Coding Standards checks.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+    # @TODO Change branch back to master once WPCS + PHPCompatibility are compatible with PHPCS 3.x.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
     # Install PHP Compatibility sniffs.
+    # @TODO ADJUST PATH FOR Composer PR when merged!
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
     # Set install path for PHPCS sniffs.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
     - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
     # After CodeSniffer install you should refresh your path.
     - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
-    # Install JSCS: JavaScript Code Style checker
+    # Install JSCS: JavaScript Code Style checker.
     # @link http://jscs.info/
     - if [[ "$SNIFF" == "1" ]]; then npm install -g jscs; fi
-    # Install JSHint, a JavaScript Code Quality Tool
+    # Install JSHint, a JavaScript Code Quality Tool.
     # @link http://jshint.com/docs/
     - if [[ "$SNIFF" == "1" ]]; then npm install -g jshint; fi
+    # (Don't) Pull in the WP Core jshint rules as they can't deal with js vars created with wp_localize_script.
+    # https://develop.svn.wordpress.org/trunk/.jshintrc
+
 
 # Run test script commands.
 # All commands must exit with code 0 on success. Anything else is considered failure.
@@ -65,16 +76,13 @@ script:
     - if [[ "$SNIFF" == "1" ]]; then jshint .; fi
     # Run through JavaScript Code Style checker.
     - if [[ "$SNIFF" == "1" ]]; then jscs .; fi
-    # WordPress Coding Standards.
+    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link https://github.com/wimg/phpcompatibility
     # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard=./phpcs.xml --extensions=php; fi
+    # Uses a custom ruleset based on WordPress.
+    # Only fails the build on errors, not warnings, but still show warnings in the output.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --standard=./phpcs.xml --runtime-set ignore_warnings_on_exit 1; fi
 
 # Receive notifications for build results.
 # @link http://docs.travis-ci.com/user/notifications/#Email-notifications

--- a/class-debug-bar-shortcodes-render.php
+++ b/class-debug-bar-shortcodes-render.php
@@ -33,7 +33,7 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 		/**
 		 * Plugin name for use in localization, class names etc.
 		 *
-		 * @var	string $name
+		 * @var string $name
 		 */
 		public static $name = 'debug-bar-shortcodes';
 
@@ -92,9 +92,13 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 							<td>' . $this->determine_callback_type( $callback ) . '</td>';
 
 					if ( true === $is_singular ) {
-						$in_use  = $this->has_shortcode( $shortcode );
-						$output .= '
-							<td>' . $this->render_image_based_on_bool( array( 'true' => esc_html__( 'Shortcode is used', 'debug-bar-shortcodes' ), 'false' => esc_html__( 'Shortcode not used', 'debug-bar-shortcodes' ) ), $in_use, true ) . '</td>
+						$alt_texts = array(
+							'true'  => esc_html__( 'Shortcode is used', 'debug-bar-shortcodes' ),
+							'false' => esc_html__( 'Shortcode not used', 'debug-bar-shortcodes' ),
+						);
+						$in_use    = $this->has_shortcode( $shortcode );
+						$output   .= '
+							<td>' . $this->render_image_based_on_bool( $alt_texts, $in_use, true ) . '</td>
 							<td>' . ( ( true === $in_use ) ? $this->find_shortcode_usage( $shortcode ) : '&nbsp;' ) . '</td>';
 						unset( $in_use );
 					}
@@ -247,7 +251,7 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 		 * Whether the current (singular) post contains the specified shortcode.
 		 *
 		 * Freely based on WP native implementation:
-		 * Source	http://core.trac.wordpress.org/browser/trunk/src/wp-includes/shortcodes.php#L144
+		 * Source: http://core.trac.wordpress.org/browser/trunk/src/wp-includes/shortcodes.php#L144
 		 * Last compared against source: 2015-12-14.
 		 *
 		 * @global object $post Current post object.
@@ -357,9 +361,9 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 		 * Retrieve a html image tag based on a value.
 		 *
 		 * @param array     $alt        Array with only three allowed keys:
-		 *                                ['true']	=>	Alt value for true image.
-		 *                                ['false']	=>	Alt value for false image.
-		 *                                ['null']	=>	Alt value for null image (status unknown).
+		 *                                ['true']  => Alt value for true image.
+		 *                                ['false'] => Alt value for false image.
+		 *                                ['null']  => Alt value for null image (status unknown).
 		 * @param bool|null $bool       The value to base the output on, either boolean or null.
 		 * @param bool      $show_false Whether to show an image if false or to return an empty string.
 		 * @param bool      $show_null  Whether to show an image if null or to return an empty string.
@@ -371,9 +375,9 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 
 			if ( ! isset( $images ) ) {
 				$images = array(
-					'true'		=> plugins_url( 'images/badge-circle-check-16.png', __FILE__ ),
-					'false'		=> plugins_url( 'images/badge-circle-cross-16.png', __FILE__ ),
-					'null'		=> plugins_url( 'images/help.png', __FILE__ ),
+					'true'  => plugins_url( 'images/badge-circle-check-16.png', __FILE__ ),
+					'false' => plugins_url( 'images/badge-circle-cross-16.png', __FILE__ ),
+					'null'  => plugins_url( 'images/help.png', __FILE__ ),
 				);
 			}
 
@@ -644,26 +648,22 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 
 				$actions = array();
 				if ( $can_edit_post && 'trash' !== $post->post_status ) {
-					/* translators: no need to translate, WP standard translation will be used. */
-					$actions['edit'] = '<a href="' . $edit_link . '" title="' . esc_attr( __( 'Edit this item' ) ) . '">';
-					/* translators: no need to translate, WP standard translation will be used. */
-					$actions['edit'] .= __( 'Edit' ) . '</a>';
+					$actions['edit']  = '<a href="' . $edit_link . '" title="' . esc_attr( __( 'Edit this item', 'debug-bar-shortcodes' ) ) . '">';
+					$actions['edit'] .= __( 'Edit', 'debug-bar-shortcodes' ) . '</a>';
 				}
 				if ( $post_type_object->public ) {
 					if ( in_array( $post->post_status, array( 'pending', 'draft', 'future' ), true ) ) {
 						if ( $can_edit_post ) {
-							/* translators: no need to translate, WP standard translation will be used. */
-							$actions['view'] = '<a href="' . esc_url( apply_filters( 'preview_post_link', set_url_scheme( add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ) ) ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;' ), $title ) ) . '" rel="permalink">';
-							/* translators: no need to translate, WP standard translation will be used. */
+							/* Translators: %s: post title for use in a link title attribute. */
+							$actions['view'] = '<a href="' . esc_url( apply_filters( 'preview_post_link', set_url_scheme( add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ) ) ) ) . '" title="' . esc_attr( sprintf( __( 'Preview &#8220;%s&#8221;', 'debug-bar-shortcodes' ), $title ) ) . '" rel="permalink">'; // WPCS: prefix ok.
 
-							$actions['view'] .= __( 'Preview' ) . '</a>';
+							$actions['view'] .= __( 'Preview', 'debug-bar-shortcodes' ) . '</a>';
 
 						}
 					} elseif ( 'trash' !== $post->post_status ) {
-						/* translators: no need to translate, WP standard translation will be used. */
-						$actions['view'] = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;' ), $title ) ) . '" rel="permalink">';
-						/* translators: no need to translate, WP standard translation will be used. */
-						$actions['view'] .= __( 'View' ) . '</a>';
+						/* Translators: %s: post title for use in a link title attribute. */
+						$actions['view']  = '<a href="' . get_permalink( $post->ID ) . '" title="' . esc_attr( sprintf( __( 'View &#8220;%s&#8221;', 'debug-bar-shortcodes' ), $title ) ) . '" rel="permalink">';
+						$actions['view'] .= __( 'View', 'debug-bar-shortcodes' ) . '</a>';
 					}
 				}
 
@@ -713,34 +713,28 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 		private function get_post_status_string( $post_status ) {
 			switch ( $post_status ) {
 				case 'publish':
-					/* translators: no need to translate, WP standard translation will be used. */
-					$post_status_string = __( 'Published' );
+					$post_status_string = __( 'Published', 'debug-bar-shortcodes' );
 					break;
 
 				case 'future':
-					/* translators: no need to translate, WP standard translation will be used. */
-					$post_status_string = __( 'Scheduled' );
+					$post_status_string = __( 'Scheduled', 'debug-bar-shortcodes' );
 					break;
 
 				case 'private':
-					/* translators: no need to translate, WP standard translation will be used. */
-					$post_status_string = __( 'Private' );
+					$post_status_string = __( 'Private', 'debug-bar-shortcodes' );
 					break;
 
 				case 'pending':
-					/* translators: no need to translate, WP standard translation will be used. */
-					$post_status_string = __( 'Pending Review' );
+					$post_status_string = __( 'Pending Review', 'debug-bar-shortcodes' );
 					break;
 
 				case 'draft':
 				case 'auto-draft':
-					/* translators: no need to translate, WP standard translation will be used. */
-					$post_status_string = __( 'Draft' );
+					$post_status_string = __( 'Draft', 'debug-bar-shortcodes' );
 					break;
 
 				case 'trash':
-					/* translators: no need to translate, WP standard translation will be used. */
-					$post_status_string = __( 'Trash' );
+					$post_status_string = __( 'Trash', 'debug-bar-shortcodes' );
 					break;
 
 				default:
@@ -789,11 +783,11 @@ if ( ! class_exists( 'Debug_Bar_Shortcodes_Render' ) ) :
 			$ajax_response = new WP_Ajax_Response();
 			$ajax_response->add(
 				array(
-					'what'			=> self::$name,
-					'action'		=> $response['action'],
-					'id'			=> $response['id'],
-					'data'			=> $data,
-					'supplemental'	=> $supplemental,
+					'what'         => self::$name,
+					'action'       => $response['action'],
+					'id'           => $response['id'],
+					'data'         => $data,
+					'supplemental' => $supplemental,
 				)
 			);
 			$ajax_response->send();

--- a/debug-bar-shortcodes.php
+++ b/debug-bar-shortcodes.php
@@ -12,16 +12,16 @@
  * @license     http://creativecommons.org/licenses/GPL/2.0/ GNU General Public License, version 2 or higher
  *
  * @wordpress-plugin
- * Plugin Name:	Debug Bar Shortcodes
- * Plugin URI:	https://wordpress.org/plugins/debug-bar-shortcodes/
- * Description:	Debug Bar Shortcodes adds a new panel to Debug Bar that displays all the registered shortcodes for the current request. Requires "Debug Bar" plugin.
- * Version:		2.0.3
- * Author:		Juliette Reinders Folmer
- * Author URI:	http://www.adviesenzo.nl/
+ * Plugin Name: Debug Bar Shortcodes
+ * Plugin URI:  https://wordpress.org/plugins/debug-bar-shortcodes/
+ * Description: Debug Bar Shortcodes adds a new panel to Debug Bar that displays all the registered shortcodes for the current request. Requires "Debug Bar" plugin.
+ * Version:     2.0.3
+ * Author:      Juliette Reinders Folmer
+ * Author URI:  http://www.adviesenzo.nl/
  * Depends:     Debug Bar
- * Text Domain:	debug-bar-shortcodes
- * Domain Path:	/languages/
- * Copyright:	2013-2016 Juliette Reinders Folmer
+ * Text Domain: debug-bar-shortcodes
+ * Domain Path: /languages/
+ * Copyright:   2013-2016 Juliette Reinders Folmer
  */
 
 // Avoid direct calls to this file.
@@ -46,10 +46,14 @@ if ( ! function_exists( 'debug_bar_shortcodes_has_parent_plugin' ) ) {
 			deactivate_plugins( $file, false, is_network_admin() );
 
 			// Add to recently active plugins list.
+			$insert = array(
+				$file => time(),
+			);
+
 			if ( ! is_network_admin() ) {
-				update_option( 'recently_activated', ( array( $file => time() ) + (array) get_option( 'recently_activated' ) ) );
+				update_option( 'recently_activated', ( $insert + (array) get_option( 'recently_activated' ) ) );
 			} else {
-				update_site_option( 'recently_activated', ( array( $file => time() ) + (array) get_site_option( 'recently_activated' ) ) );
+				update_site_option( 'recently_activated', ( $insert + (array) get_site_option( 'recently_activated' ) ) );
 			}
 
 			// Prevent trying again on page reload.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,7 +13,7 @@
 	<!-- ##### PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>
-	
+
 	<rule ref="PHPCompatibility.PHP.NewClosure">
 		<exclude-pattern>*/php53/php5.3-closure-test.php</exclude-pattern>
 	</rule>
@@ -21,12 +21,53 @@
 
 	<!-- ##### WordPress sniffs #####-->
 	<rule ref="WordPress">
-		<exclude name="WordPress.VIP" />
 		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
+
+		<!-- Way too overzealous. -->
+		<exclude name="WordPress.VIP.ValidatedSanitizedInput"/>
+	</rule>
+
+	<!-- ##### Customizations #####-->
+
+	<!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="debug-bar-shortcodes" />
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="Debug_Bar_Shortcode,Debug_Bar_Shortcodes,db_shortcodes" />
+		</properties>
+	</rule>
+
+	<!-- Verify that no WP functions are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 supported by the Debug Bar extension. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="3.6" />
+		</properties>
+	</rule>
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="3.6" />
+		</properties>
 	</rule>
 
 
-	<!-- exclude the 'empty' index files from some documentation checks -->
+	<!-- ##### Exlusions #####-->
+
+	<!-- Exclude a number of files from the "file name must match class name" sniff. -->
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>*/shortcode-info/class-shortcode-info*.php</exclude-pattern>
+	</rule>
+
+	<!-- Exclude the 'empty' index files from some documentation checks. -->
 	<rule ref="Squiz.Commenting.FileComment.WrongStyle">
 		<exclude-pattern>*/index.php</exclude-pattern>
 	</rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,14 @@
 <ruleset name="Debug Bar Shortcodes">
 	<description>The code standard for Debug Bar Shortcodes is WordPress.</description>
 
+	<!-- Show progress & sniff codes. -->
+	<arg value="ps"/>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
 	<!-- ##### PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>

--- a/shortcode-info/class-shortcode-info-defaults.php
+++ b/shortcode-info/class-shortcode-info-defaults.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'Debug_Bar_Shortcode_Info_Defaults' ) ) :
 		 * Parameters which can be passed to the shortcode.
 		 *
 		 * Array format:
-		 * - [required]	=> array Required parameters.
+		 * - [required] => array Required parameters.
 		 *                       Array format:
 		 *                       - key   = name of the parameter.
 		 *                       - value = description of the parameter.

--- a/shortcode-info/class-shortcode-info-lhr.php
+++ b/shortcode-info/class-shortcode-info-lhr.php
@@ -45,14 +45,14 @@ if ( ! class_exists( 'Debug_Bar_Shortcode_Info_LHR' ) ) :
 		 */
 		public function __construct( $shortcode = '' ) {
 			$this->lhr_defaults = array(
-				'scTag'		=> $shortcode,
-				'scName'	=> $shortcode,
-				'scDesc'	=> __( 'No information available', 'debug-bar-shortcodes' ),
-				'scSelfCls'	=> 'u', // Unknown.
-				'scReqP'	=> array(),
-				'scOptP'	=> array(),
+				'scTag'     => $shortcode,
+				'scName'    => $shortcode,
+				'scDesc'    => __( 'No information available', 'debug-bar-shortcodes' ),
+				'scSelfCls' => 'u', // Unknown.
+				'scReqP'    => array(),
+				'scOptP'    => array(),
 			);
-			$this->lhr_info     = apply_filters( 'sim_' . $shortcode, $this->lhr_defaults );
+			$this->lhr_info     = apply_filters( 'sim_' . $shortcode, $this->lhr_defaults ); // WPCS: prefix ok.
 
 			$this->set_name();
 			$this->set_description();

--- a/shortcode-info/class-shortcode-info-validator.php
+++ b/shortcode-info/class-shortcode-info-validator.php
@@ -70,8 +70,12 @@ if ( ! class_exists( 'Debug_Bar_Shortcode_Info_Validator' ) ) :
 		 * Validate a shortcode description.
 		 */
 		private function validate_description() {
+			$kses_allowed = array(
+				'br' => array(),
+			);
+
 			if ( isset( $this->dirty->description ) && is_string( $this->dirty->description ) && '' !== trim( $this->dirty->description ) ) {
-				$this->description = wp_kses( trim( $this->dirty->description ), array( 'br' => array() ) );
+				$this->description = wp_kses( trim( $this->dirty->description ), $kses_allowed );
 			}
 		}
 

--- a/shortcode-info/class-shortcode-info.php
+++ b/shortcode-info/class-shortcode-info.php
@@ -29,7 +29,7 @@ if ( ! class_exists( 'Debug_Bar_Shortcode_Info' ) ) :
 		/**
 		 * Defaults.
 		 *
-		 * @var	\Debug_Bar_Shortcode_Info_Defaults $defaults
+		 * @var \Debug_Bar_Shortcode_Info_Defaults $defaults
 		 */
 		protected $defaults;
 


### PR DESCRIPTION
### Update Travis build script
* Include PHP 5.3, 5.5 and nightly in the build matrix and remove HHVM.
* Use `before_install` rather than `before_script` to better distinguish between failed install or failed build.
* Use the PHPCS `2.9` branch until the external standards are compatible with PHPCS 3.x.
* Use the WPCS `develop` branch to benefit from the latest sniffs.
* Use the WP native JSHint rules and pull these in for the build instead of maintaining a copy.
* Move the standard PHPCS command line arguments to the custom ruleset.
* Show PHPCS warnings, but don't fail the build on it.

### Update the PHPCS ruleset for WPCS 0.12.0
* Reviewed exclusions & made more specific.
* Verify that the correct text domain is being used.
* Verify that everything in the global namespace is prefixed correctly.
* Verify that no WP deprecated functions or classes are used.

### Minor codestyle fixes