### PR TITLE
README: Add "Requires PHP" header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@ Requires at least: 3.6
 Tested up to: 4.4
 Stable tag: 2.0.3
 Depends: Debug Bar
+Requires PHP: 5.2.4
 License: GPLv2
 
 Debug Bar Shortcodes adds a new panel to the Debug Bar that displays the registered shortcodes for the current request.


### PR DESCRIPTION
This new header has been soft launched on August 25th 2017.

Refs:
* https://meta.trac.wordpress.org/ticket/2952
* https://meta.trac.wordpress.org/changeset/5841

https://wordpress.org/plugins/developers/readme-validator/